### PR TITLE
Add support for guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "php": "^7.1.3",
     "ext-curl": "*",
     "jms/serializer": "^1.0|^2.0|^3.0",
+    "guzzlehttp/guzzle": "^6.0|^7.0",
     "symfony/event-dispatcher": "^2.3|^3.0|^4.0|^5.0",
     "symfony/yaml": "^2.3|^3.0|^4.0|^5.0",
-    "guzzlehttp/guzzle": "^6.0",
     "doctrine/collections": "^1.2"
   },
   "require-dev": {


### PR DESCRIPTION
Adding support for Guzzle 7 which makes it so that this package can be installed alongside Laravel 8.0+

I checked that all tests pass with Guzzle 7